### PR TITLE
feat: Introduce agentic_use caching strategy

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -19,6 +19,7 @@ package org.springframework.ai.anthropic;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -107,6 +108,8 @@ public class AnthropicChatModel implements ChatModel {
 	public static final Integer DEFAULT_MAX_TOKENS = 500;
 
 	public static final Double DEFAULT_TEMPERATURE = 0.8;
+
+	private static final int DEFAULT_MIN_CACHEABLE_PROMPT_LENGTH = 1024;
 
 	private static final Logger logger = LoggerFactory.getLogger(AnthropicChatModel.class);
 
@@ -713,10 +716,6 @@ public class AnthropicChatModel implements ChatModel {
 		// candidates
 		Set<Integer> agenticBreakpointIndices = Set.of();
 		if (cacheEligibilityResolver.getStrategy() == AnthropicCacheStrategy.AGENTIC_TOOL_USE) {
-			String requestModel = null;
-			if (prompt.getOptions() instanceof AnthropicChatOptions anthropicChatOptions) {
-				requestModel = anthropicChatOptions.getModel();
-			}
 			agenticBreakpointIndices = findAgenticBreakpointCandidates(allMessages, cacheEligibilityResolver);
 		}
 
@@ -883,8 +882,8 @@ public class AnthropicChatModel implements ChatModel {
 
 	/**
 	 * Find optimal breakpoint candidate for AGENTIC_TOOL_USE strategy. This method finds
-	 * the last TOOL message in the conversation to place a cache breakpoint. All content
-	 * before this breakpoint will be cached by Anthropic.
+	 * the last TOOL message or last ASSISTANT in the conversation to place a cache
+	 * breakpoint. All content before this breakpoint will be cached by Anthropic.
 	 * @param allMessages list of all messages (excluding SYSTEM)
 	 * @param cacheEligibilityResolver the cache eligibility resolver with configuration
 	 * @return set of message indices that should have cache breakpoints applied
@@ -892,7 +891,7 @@ public class AnthropicChatModel implements ChatModel {
 	private Set<Integer> findAgenticBreakpointCandidates(List<Message> allMessages,
 			CacheEligibilityResolver cacheEligibilityResolver) {
 
-		Set<Integer> breakpointIndices = new java.util.HashSet<>();
+		Set<Integer> breakpointIndices = new HashSet<>();
 		int remainingBreakpoints = cacheEligibilityResolver.getRemainingBreakpoints();
 
 		// Reserve at least 1 breakpoint for messages (tools and system may use others)
@@ -978,7 +977,7 @@ public class AnthropicChatModel implements ChatModel {
 		if (override != null && override > 0) {
 			return override;
 		}
-		return 1024;
+		return DEFAULT_MIN_CACHEABLE_PROMPT_LENGTH;
 	}
 
 	private static int estimateDeltaBetweenIndices(List<Message> allMessages, int fromIndexExclusive, int toIndex,

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -43,6 +43,7 @@ import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock.Source;
 import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock.Type;
 import org.springframework.ai.anthropic.api.AnthropicApi.Role;
 import org.springframework.ai.anthropic.api.AnthropicCacheOptions;
+import org.springframework.ai.anthropic.api.AnthropicCacheStrategy;
 import org.springframework.ai.anthropic.api.AnthropicCacheTtl;
 import org.springframework.ai.anthropic.api.CitationDocument;
 import org.springframework.ai.anthropic.api.utils.CacheEligibilityResolver;
@@ -80,6 +81,7 @@ import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.json.JsonParser;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
@@ -708,9 +710,22 @@ public class AnthropicChatModel implements ChatModel {
 			.filter(message -> message.getMessageType() != MessageType.SYSTEM)
 			.toList();
 
+		// For AGENTIC_TOOL_USE strategy, use backward-scan to find optimal breakpoint
+		// candidates
+		Set<Integer> agenticBreakpointIndices = Set.of();
+		if (cacheEligibilityResolver.getStrategy() == AnthropicCacheStrategy.AGENTIC_TOOL_USE) {
+			String requestModel = null;
+			if (prompt.getOptions() instanceof AnthropicChatOptions anthropicChatOptions) {
+				requestModel = anthropicChatOptions.getModel();
+			}
+			agenticBreakpointIndices = findAgenticBreakpointCandidates(allMessages, cacheEligibilityResolver,
+					requestModel);
+		}
+
 		// Find the last user message (current question) for CONVERSATION_HISTORY strategy
 		int lastUserIndex = -1;
-		if (cacheEligibilityResolver.isCachingEnabled()) {
+		if (cacheEligibilityResolver.isCachingEnabled()
+				&& cacheEligibilityResolver.getStrategy() != AnthropicCacheStrategy.AGENTIC_TOOL_USE) {
 			for (int i = allMessages.size() - 1; i >= 0; i--) {
 				if (allMessages.get(i).getMessageType() == MessageType.USER) {
 					lastUserIndex = i;
@@ -776,6 +791,7 @@ public class AnthropicChatModel implements ChatModel {
 				result.add(new AnthropicMessage(contentBlocks, Role.valueOf(message.getMessageType().name())));
 			}
 			else if (messageType == MessageType.ASSISTANT) {
+				final boolean shouldApplyAgenticBreakpoint = agenticBreakpointIndices.contains(i);
 				AssistantMessage assistantMessage = (AssistantMessage) message;
 				List<ContentBlock> contentBlocks = new ArrayList<>();
 
@@ -792,24 +808,53 @@ public class AnthropicChatModel implements ChatModel {
 				}
 
 				if (StringUtils.hasText(message.getText())) {
-					contentBlocks.add(cacheAwareContentBlock(new ContentBlock(message.getText()), messageType,
-							cacheEligibilityResolver));
+					if (cacheEligibilityResolver.getStrategy() == AnthropicCacheStrategy.AGENTIC_TOOL_USE) {
+						// In agentic mode we normally avoid caching assistant text, but
+						// if the
+						// breakpoint planner selected this message, apply cache_control
+						// here.
+						ContentBlock textBlock = new ContentBlock(message.getText());
+						contentBlocks.add(shouldApplyAgenticBreakpoint
+								? cacheAwareContentBlock(textBlock, messageType, cacheEligibilityResolver) : textBlock);
+					}
+					else {
+						contentBlocks.add(cacheAwareContentBlock(new ContentBlock(message.getText()), messageType,
+								cacheEligibilityResolver));
+					}
 				}
 				if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 					for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
 						ContentBlock contentBlock = new ContentBlock(Type.TOOL_USE, toolCall.id(), toolCall.name(),
 								ModelOptionsUtils.jsonToMap(toolCall.arguments()));
-						contentBlocks.add(cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver));
+						if (cacheEligibilityResolver.getStrategy() == AnthropicCacheStrategy.AGENTIC_TOOL_USE) {
+							contentBlocks.add(contentBlock);
+						}
+						else {
+							contentBlocks
+								.add(cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver));
+						}
 					}
 				}
 				result.add(new AnthropicMessage(contentBlocks, Role.ASSISTANT));
 			}
 			else if (messageType == MessageType.TOOL) {
+				final boolean shouldApplyAgenticBreakpoint = agenticBreakpointIndices.contains(i);
 				List<ContentBlock> toolResponses = ((ToolResponseMessage) message).getResponses()
 					.stream()
 					.map(toolResponse -> new ContentBlock(Type.TOOL_RESULT, toolResponse.id(),
 							toolResponse.responseData()))
-					.map(contentBlock -> cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver))
+					.map(contentBlock -> {
+						// For AGENTIC_TOOL_USE, only apply cache to selected breakpoint
+						// indices
+						if (shouldApplyAgenticBreakpoint) {
+							return cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver);
+						}
+						// For other strategies, use standard caching logic
+						else if (cacheEligibilityResolver.getStrategy() != AnthropicCacheStrategy.AGENTIC_TOOL_USE) {
+							return cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver);
+						}
+						return contentBlock;
+					})
 					.toList();
 				result.add(new AnthropicMessage(toolResponses, Role.USER));
 			}
@@ -836,6 +881,135 @@ public class AnthropicChatModel implements ChatModel {
 			}
 		}
 		return sb.toString();
+	}
+
+	/**
+	 * Find optimal breakpoint candidate for AGENTIC_TOOL_USE strategy. This method finds
+	 * the last TOOL message in the conversation to place a cache breakpoint. All content
+	 * before this breakpoint will be cached by Anthropic.
+	 * @param allMessages list of all messages (excluding SYSTEM)
+	 * @param cacheEligibilityResolver the cache eligibility resolver with configuration
+	 * @return set of message indices that should have cache breakpoints applied
+	 */
+	private Set<Integer> findAgenticBreakpointCandidates(List<Message> allMessages,
+			CacheEligibilityResolver cacheEligibilityResolver, @Nullable String requestModel) {
+
+		Set<Integer> breakpointIndices = new java.util.HashSet<>();
+		int remainingBreakpoints = cacheEligibilityResolver.getRemainingBreakpoints();
+
+		// Reserve at least 1 breakpoint for messages (tools and system may use others)
+		if (remainingBreakpoints < 1) {
+			logger.debug("AGENTIC_TOOL_USE: No remaining breakpoints available for messages");
+			return breakpointIndices;
+		}
+
+		int lastToolIndex = findLastToolIndex(allMessages);
+
+		int lastStableAssistantIndex = findLastStableAssistantWithoutToolCallsIndex(allMessages);
+
+		int minCacheableDelta = resolveMinCacheablePromptLength(cacheEligibilityResolver, requestModel);
+
+		// If there are no TOOL messages at all, fall back to a "dialog" mode:
+		// prefer caching a stable, large ASSISTANT block (no toolCalls).
+		int baselineIndex = lastToolIndex;
+		int selectedIndex = lastToolIndex;
+		String selectedReason = "fallback to last TOOL";
+		if (lastToolIndex < 0) {
+			baselineIndex = -1;
+			selectedIndex = -1;
+			selectedReason = "no TOOL messages";
+		}
+
+		// Prefer the last stable ASSISTANT (no toolCalls) if the delta since baseline is
+		// large enough to justify a cache write and meet Anthropic min cacheable length.
+		if (lastStableAssistantIndex > baselineIndex) {
+			int delta = estimateDeltaBetweenIndices(allMessages, baselineIndex, lastStableAssistantIndex,
+					cacheEligibilityResolver);
+			if (delta >= minCacheableDelta) {
+				selectedIndex = lastStableAssistantIndex;
+				selectedReason = (lastToolIndex < 0) ? "dialog mode: ASSISTANT delta >= minCacheableDelta"
+						: "delta since last TOOL >= minCacheableDelta on stable ASSISTANT";
+			}
+			logger.debug(
+					"AGENTIC_TOOL_USE: candidate ASSISTANT index={}, baselineIndex={}, delta={}, minCacheableDelta={} -> {}",
+					lastStableAssistantIndex, baselineIndex, delta, minCacheableDelta, selectedReason);
+		}
+
+		// Nothing eligible.
+		if (selectedIndex < 0) {
+			logger.debug("AGENTIC_TOOL_USE: No suitable message found for cache breakpoint");
+			return breakpointIndices;
+		}
+
+		breakpointIndices.add(selectedIndex);
+		logger.debug("AGENTIC_TOOL_USE: Selected message at index {} for cache breakpoint ({})", selectedIndex,
+				selectedReason);
+
+		return breakpointIndices;
+	}
+
+	private static int findLastToolIndex(List<Message> allMessages) {
+		for (int i = allMessages.size() - 1; i >= 0; i--) {
+			if (allMessages.get(i).getMessageType() == MessageType.TOOL) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static int findLastStableAssistantWithoutToolCallsIndex(List<Message> allMessages) {
+		for (int i = allMessages.size() - 1; i >= 0; i--) {
+			Message m = allMessages.get(i);
+			if (m.getMessageType() != MessageType.ASSISTANT) {
+				continue;
+			}
+			AssistantMessage assistant = (AssistantMessage) m;
+			if (!CollectionUtils.isEmpty(assistant.getToolCalls())) {
+				continue;
+			}
+			if (!StringUtils.hasText(assistant.getText())) {
+				continue;
+			}
+			return i;
+		}
+		return -1;
+	}
+
+	private static int resolveMinCacheablePromptLength(CacheEligibilityResolver cacheEligibilityResolver,
+			@Nullable String requestModel) {
+		Integer override = cacheEligibilityResolver.getMinCacheablePromptLength();
+		if (override != null && override > 0) {
+			return override;
+		}
+		// Defaults based on Anthropic docs (approximate; can be overridden).
+		if (requestModel == null) {
+			return 1024;
+		}
+		// Opus 4.5 and Haiku 4.5 require 4096; Haiku 3 requires 2048; most others are
+		// 1024.
+		if (requestModel.contains("opus-4-5") || requestModel.contains("haiku-4-5")) {
+			return 4096;
+		}
+		if (requestModel.contains("haiku") && requestModel.contains("3")) {
+			return 2048;
+		}
+		return 1024;
+	}
+
+	private static int estimateDeltaBetweenIndices(List<Message> allMessages, int fromIndexExclusive, int toIndex,
+			CacheEligibilityResolver cacheEligibilityResolver) {
+		if (toIndex <= fromIndexExclusive) {
+			return 0;
+		}
+		StringBuilder sb = new StringBuilder();
+		for (int i = fromIndexExclusive + 1; i <= toIndex; i++) {
+			Message m = allMessages.get(i);
+			String t = m.getText();
+			if (StringUtils.hasText(t)) {
+				sb.append(t);
+			}
+		}
+		return cacheEligibilityResolver.getTokenLengthFunction().apply(sb.toString());
 	}
 
 	/**

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -81,7 +81,6 @@ import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.json.JsonParser;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
@@ -718,8 +717,7 @@ public class AnthropicChatModel implements ChatModel {
 			if (prompt.getOptions() instanceof AnthropicChatOptions anthropicChatOptions) {
 				requestModel = anthropicChatOptions.getModel();
 			}
-			agenticBreakpointIndices = findAgenticBreakpointCandidates(allMessages, cacheEligibilityResolver,
-					requestModel);
+			agenticBreakpointIndices = findAgenticBreakpointCandidates(allMessages, cacheEligibilityResolver);
 		}
 
 		// Find the last user message (current question) for CONVERSATION_HISTORY strategy
@@ -892,7 +890,7 @@ public class AnthropicChatModel implements ChatModel {
 	 * @return set of message indices that should have cache breakpoints applied
 	 */
 	private Set<Integer> findAgenticBreakpointCandidates(List<Message> allMessages,
-			CacheEligibilityResolver cacheEligibilityResolver, @Nullable String requestModel) {
+			CacheEligibilityResolver cacheEligibilityResolver) {
 
 		Set<Integer> breakpointIndices = new java.util.HashSet<>();
 		int remainingBreakpoints = cacheEligibilityResolver.getRemainingBreakpoints();
@@ -907,7 +905,7 @@ public class AnthropicChatModel implements ChatModel {
 
 		int lastStableAssistantIndex = findLastStableAssistantWithoutToolCallsIndex(allMessages);
 
-		int minCacheableDelta = resolveMinCacheablePromptLength(cacheEligibilityResolver, requestModel);
+		int minCacheableDelta = resolveMinCacheablePromptLength(cacheEligibilityResolver);
 
 		// If there are no TOOL messages at all, fall back to a "dialog" mode:
 		// prefer caching a stable, large ASSISTANT block (no toolCalls).
@@ -975,23 +973,10 @@ public class AnthropicChatModel implements ChatModel {
 		return -1;
 	}
 
-	private static int resolveMinCacheablePromptLength(CacheEligibilityResolver cacheEligibilityResolver,
-			@Nullable String requestModel) {
+	private static int resolveMinCacheablePromptLength(CacheEligibilityResolver cacheEligibilityResolver) {
 		Integer override = cacheEligibilityResolver.getMinCacheablePromptLength();
 		if (override != null && override > 0) {
 			return override;
-		}
-		// Defaults based on Anthropic docs (approximate; can be overridden).
-		if (requestModel == null) {
-			return 1024;
-		}
-		// Opus 4.5 and Haiku 4.5 require 4096; Haiku 3 requires 2048; most others are
-		// 1024.
-		if (requestModel.contains("opus-4-5") || requestModel.contains("haiku-4-5")) {
-			return 4096;
-		}
-		if (requestModel.contains("haiku") && requestModel.contains("3")) {
-			return 2048;
 		}
 		return 1024;
 	}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheOptions.java
@@ -39,6 +39,17 @@ public class AnthropicCacheOptions {
 	private AnthropicCacheStrategy strategy = AnthropicCacheStrategy.NONE;
 
 	/**
+	 * Optional override for the minimum cacheable prompt length (in tokens) required by
+	 * the Anthropic backend for caching to take effect.
+	 * <p>
+	 * If {@code null}, the client will use model-specific defaults.
+	 * <p>
+	 * Note: this is separate from {@link #messageTypeMinContentLengths}, which controls
+	 * eligibility of an individual block for consuming a breakpoint.
+	 */
+	private Integer minCacheablePromptLength;
+
+	/**
 	 * Function to determine the content length of a message. Defaults to the length of
 	 * the string, or {@code 0} if the string is {@code null}. This is used as a proxy for
 	 * number of tokens because Anthropic does document that messages with too few tokens
@@ -48,6 +59,21 @@ public class AnthropicCacheOptions {
 	 * accurate token count if desired.
 	 */
 	private Function<String, Integer> contentLengthFunction = s -> s != null ? s.length() : 0;
+
+	/**
+	 * Function to estimate token length.
+	 * <p>
+	 * Defaults to {@code ceil(chars/4)}. This function is intended for token-based
+	 * thresholds such as {@link #minCacheablePromptLength} and agentic delta planning.
+	 * <p>
+	 * You can customize this function to use a more accurate tokenizer if desired.
+	 */
+	private Function<String, Integer> tokenLengthFunction = s -> {
+		if (s == null || s.isEmpty()) {
+			return 0;
+		}
+		return (s.length() + 3) / 4;
+	};
 
 	/**
 	 * Configure on a per {@link MessageType} basis the TTL (time-to-live) for cached
@@ -85,6 +111,22 @@ public class AnthropicCacheOptions {
 		return this.contentLengthFunction;
 	}
 
+	public Function<String, Integer> getTokenLengthFunction() {
+		return this.tokenLengthFunction;
+	}
+
+	public void setTokenLengthFunction(Function<String, Integer> tokenLengthFunction) {
+		this.tokenLengthFunction = tokenLengthFunction;
+	}
+
+	public Integer getMinCacheablePromptLength() {
+		return this.minCacheablePromptLength;
+	}
+
+	public void setMinCacheablePromptLength(Integer minCacheablePromptLength) {
+		this.minCacheablePromptLength = minCacheablePromptLength;
+	}
+
 	public void setContentLengthFunction(Function<String, Integer> contentLengthFunction) {
 		this.contentLengthFunction = contentLengthFunction;
 	}
@@ -108,8 +150,9 @@ public class AnthropicCacheOptions {
 	@Override
 	public String toString() {
 		return "AnthropicCacheOptions{" + "strategy=" + this.strategy + ", contentLengthFunction="
-				+ this.contentLengthFunction + ", messageTypeTtl=" + this.messageTypeTtl
-				+ ", messageTypeMinContentLengths=" + this.messageTypeMinContentLengths + '}';
+				+ this.contentLengthFunction + ", tokenLengthFunction=" + this.tokenLengthFunction
+				+ ", minCacheablePromptLength=" + this.minCacheablePromptLength + ", messageTypeTtl="
+				+ this.messageTypeTtl + ", messageTypeMinContentLengths=" + this.messageTypeMinContentLengths + '}';
 	}
 
 	public static final class Builder {
@@ -123,6 +166,16 @@ public class AnthropicCacheOptions {
 
 		public Builder contentLengthFunction(Function<String, Integer> contentLengthFunction) {
 			this.options.setContentLengthFunction(contentLengthFunction);
+			return this;
+		}
+
+		public Builder tokenLengthFunction(Function<String, Integer> tokenLengthFunction) {
+			this.options.setTokenLengthFunction(tokenLengthFunction);
+			return this;
+		}
+
+		public Builder minCacheablePromptLength(Integer minCacheablePromptLength) {
+			this.options.setMinCacheablePromptLength(minCacheablePromptLength);
 			return this;
 		}
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheStrategy.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheStrategy.java
@@ -121,6 +121,36 @@ public enum AnthropicCacheStrategy {
 	 * entire conversation cache due to cascade invalidation. Tool and system stability is
 	 * critical for this strategy.
 	 */
-	CONVERSATION_HISTORY
+	CONVERSATION_HISTORY,
+
+	/**
+	 * Optimized caching strategy for agentic tool-use loops. Places a cache breakpoint on
+	 * the optimal message in the conversation, allowing the cache boundary to advance as
+	 * tool results are appended.
+	 * <p>
+	 * Use this when:
+	 * <ul>
+	 * <li>Running multi-iteration tool loops (agentic mode)</li>
+	 * <li>Conversation history grows with ASSISTANT(tool_use) and TOOL(tool_result)
+	 * blocks</li>
+	 * <li>The initial USER request is stable across the loop</li>
+	 * </ul>
+	 * <p>
+	 * <strong>Behavior:</strong> Uses backward-scan to find the optimal breakpoint:
+	 * <ul>
+	 * <li>Primary target: the last TOOL message (tool_result)</li>
+	 * <li>Fallback: if a stable ASSISTANT message (without toolCalls) exists after the
+	 * last TOOL and the token delta since the last TOOL meets the minimum cacheable
+	 * threshold, the breakpoint moves to that ASSISTANT message</li>
+	 * <li>Skips USER messages (mutable content, e.g., dynamic file lists)</li>
+	 * <li>Skips ASSISTANT messages with toolCalls (tool_use JSON is unstable for
+	 * caching)</li>
+	 * </ul>
+	 * <p>
+	 * <strong>Important:</strong> This strategy is designed for append-only conversation
+	 * histories where tool results grow over multiple iterations. All content before the
+	 * breakpoint will be cached by Anthropic.
+	 */
+	AGENTIC_TOOL_USE
 
 }

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/utils/CacheEligibilityResolver.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/utils/CacheEligibilityResolver.java
@@ -62,23 +62,31 @@ public class CacheEligibilityResolver {
 
 	private final Function<String, Integer> contentLengthFunction;
 
+	private final Function<String, Integer> tokenLengthFunction;
+
 	private final Set<MessageType> cacheEligibleMessageTypes;
+
+	private final Integer minCacheablePromptLength;
 
 	public CacheEligibilityResolver(AnthropicCacheStrategy cacheStrategy,
 			Map<MessageType, AnthropicCacheTtl> messageTypeTtl, Map<MessageType, Integer> messageTypeMinContentLengths,
-			Function<String, Integer> contentLengthFunction, Set<MessageType> cacheEligibleMessageTypes) {
+			Function<String, Integer> contentLengthFunction, Function<String, Integer> tokenLengthFunction,
+			Set<MessageType> cacheEligibleMessageTypes, Integer minCacheablePromptLength) {
 		this.cacheStrategy = cacheStrategy;
 		this.messageTypeTtl = messageTypeTtl;
 		this.messageTypeMinContentLengths = messageTypeMinContentLengths;
 		this.contentLengthFunction = contentLengthFunction;
+		this.tokenLengthFunction = tokenLengthFunction;
 		this.cacheEligibleMessageTypes = cacheEligibleMessageTypes;
+		this.minCacheablePromptLength = minCacheablePromptLength;
 	}
 
 	public static CacheEligibilityResolver from(AnthropicCacheOptions anthropicCacheOptions) {
 		AnthropicCacheStrategy strategy = anthropicCacheOptions.getStrategy();
 		return new CacheEligibilityResolver(strategy, anthropicCacheOptions.getMessageTypeTtl(),
 				anthropicCacheOptions.getMessageTypeMinContentLengths(),
-				anthropicCacheOptions.getContentLengthFunction(), extractEligibleMessageTypes(strategy));
+				anthropicCacheOptions.getContentLengthFunction(), anthropicCacheOptions.getTokenLengthFunction(),
+				extractEligibleMessageTypes(strategy), anthropicCacheOptions.getMinCacheablePromptLength());
 	}
 
 	private static Set<MessageType> extractEligibleMessageTypes(AnthropicCacheStrategy anthropicCacheStrategy) {
@@ -86,7 +94,12 @@ public class CacheEligibilityResolver {
 			case NONE -> Set.of();
 			case SYSTEM_ONLY, SYSTEM_AND_TOOLS -> Set.of(MessageType.SYSTEM);
 			case TOOLS_ONLY -> Set.of(); // No message types cached, only tool definitions
-			case CONVERSATION_HISTORY -> Set.of(MessageType.values());
+			// For CONVERSATION_HISTORY and AGENTIC_TOOL_USE, all message types are
+			// potentially eligible for caching. However, for AGENTIC_TOOL_USE the actual
+			// cache application is controlled by agenticBreakpointIndices in buildMessages(),
+			// which selects only specific messages (last TOOL or stable ASSISTANT) for
+			// breakpoints.
+			case CONVERSATION_HISTORY, AGENTIC_TOOL_USE -> Set.of(MessageType.values());
 		};
 	}
 
@@ -110,12 +123,14 @@ public class CacheEligibilityResolver {
 	}
 
 	public AnthropicApi.ChatCompletionRequest.CacheControl resolveToolCacheControl() {
-		// Tool definitions are cache-eligible for TOOLS_ONLY, SYSTEM_AND_TOOLS, and
-		// CONVERSATION_HISTORY strategies. SYSTEM_ONLY caches only system messages,
-		// relying on Anthropic's cache hierarchy to implicitly cache tools.
+		// Tool definitions are cache-eligible for TOOLS_ONLY, SYSTEM_AND_TOOLS,
+		// CONVERSATION_HISTORY, and AGENTIC_TOOL_USE strategies. SYSTEM_ONLY caches only
+		// system messages, relying on Anthropic's cache hierarchy to implicitly cache
+		// tools.
 		if (this.cacheStrategy != AnthropicCacheStrategy.TOOLS_ONLY
 				&& this.cacheStrategy != AnthropicCacheStrategy.SYSTEM_AND_TOOLS
-				&& this.cacheStrategy != AnthropicCacheStrategy.CONVERSATION_HISTORY) {
+				&& this.cacheStrategy != AnthropicCacheStrategy.CONVERSATION_HISTORY
+				&& this.cacheStrategy != AnthropicCacheStrategy.AGENTIC_TOOL_USE) {
 			logger.debug("Caching not enabled for tool definition, cacheStrategy={}", this.cacheStrategy);
 			return null;
 		}
@@ -139,6 +154,30 @@ public class CacheEligibilityResolver {
 
 	public void useCacheBlock() {
 		this.cacheBreakpointTracker.use();
+	}
+
+	public AnthropicCacheStrategy getStrategy() {
+		return this.cacheStrategy;
+	}
+
+	public Function<String, Integer> getContentLengthFunction() {
+		return this.contentLengthFunction;
+	}
+
+	public Function<String, Integer> getTokenLengthFunction() {
+		return this.tokenLengthFunction;
+	}
+
+	public int getRemainingBreakpoints() {
+		return 4 - this.cacheBreakpointTracker.getCount();
+	}
+
+	public Integer getMinCacheablePromptLength() {
+		return this.minCacheablePromptLength;
+	}
+
+	public Map<MessageType, AnthropicCacheTtl> getMessageTypeTtl() {
+		return this.messageTypeTtl;
 	}
 
 }

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/utils/CacheEligibilityResolver.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/utils/CacheEligibilityResolver.java
@@ -96,7 +96,8 @@ public class CacheEligibilityResolver {
 			case TOOLS_ONLY -> Set.of(); // No message types cached, only tool definitions
 			// For CONVERSATION_HISTORY and AGENTIC_TOOL_USE, all message types are
 			// potentially eligible for caching. However, for AGENTIC_TOOL_USE the actual
-			// cache application is controlled by agenticBreakpointIndices in buildMessages(),
+			// cache application is controlled by agenticBreakpointIndices in
+			// buildMessages(),
 			// which selects only specific messages (last TOOL or stable ASSISTANT) for
 			// breakpoints.
 			case CONVERSATION_HISTORY, AGENTIC_TOOL_USE -> Set.of(MessageType.values());

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/ChatCompletionRequestTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/ChatCompletionRequestTests.java
@@ -290,7 +290,8 @@ public class ChatCompletionRequestTests {
 
 		var promptOptions = AnthropicChatOptions.builder().cacheOptions(cacheOptions).build();
 
-		// Realistic agentic loop: USER -> ASSISTANT(toolCalls) -> TOOL -> ASSISTANT(toolCalls) -> TOOL
+		// Realistic agentic loop: USER -> ASSISTANT(toolCalls) -> TOOL ->
+		// ASSISTANT(toolCalls) -> TOOL
 		List<Message> messages = List.of(new UserMessage("Analyze the codebase and find bugs"),
 				AssistantMessage.builder()
 					.content("I'll start by reading the main file")
@@ -298,8 +299,8 @@ public class ChatCompletionRequestTests {
 						.of(new AssistantMessage.ToolCall("call-1", "tool_use", "read_file", "{\"path\":\"main.py\"}")))
 					.build(),
 				ToolResponseMessage.builder()
-					.responses(List.of(
-							new ToolResponseMessage.ToolResponse("call-1", "read_file", "def main(): print('hello')")))
+					.responses(List
+						.of(new ToolResponseMessage.ToolResponse("call-1", "read_file", "def main(): print('hello')")))
 					.build(),
 				AssistantMessage.builder()
 					.content("Now I'll check the tests")
@@ -307,8 +308,8 @@ public class ChatCompletionRequestTests {
 						.of(new AssistantMessage.ToolCall("call-2", "tool_use", "read_file", "{\"path\":\"test.py\"}")))
 					.build(),
 				ToolResponseMessage.builder()
-					.responses(List.of(
-							new ToolResponseMessage.ToolResponse("call-2", "read_file", "def test_main(): assert True")))
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call-2", "read_file",
+							"def test_main(): assert True")))
 					.build());
 
 		var request = client.createRequest(new Prompt(messages, promptOptions), false);

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/ChatCompletionRequestTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/ChatCompletionRequestTests.java
@@ -16,9 +16,19 @@
 
 package org.springframework.ai.anthropic;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.anthropic.api.AnthropicCacheOptions;
+import org.springframework.ai.anthropic.api.AnthropicCacheStrategy;
+import org.springframework.ai.anthropic.api.AnthropicCacheTtl;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,6 +133,222 @@ public class ChatCompletionRequestTests {
 		assertThat(request.toolChoice()).isNotNull();
 		assertThat(request.toolChoice()).isInstanceOf(AnthropicApi.ToolChoiceAuto.class);
 		assertThat(((AnthropicApi.ToolChoiceAuto) request.toolChoice()).disableParallelToolUse()).isTrue();
+	}
+
+	@Test
+	void agenticToolUseCachesOnlyLastToolResultMessage() {
+		var client = AnthropicChatModel.builder()
+			.anthropicApi(AnthropicApi.builder().apiKey("TEST").build())
+			.defaultOptions(AnthropicChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.AGENTIC_TOOL_USE)
+			.messageTypeTtl(MessageType.TOOL, AnthropicCacheTtl.FIVE_MINUTES)
+			// Make the threshold huge so no delta-based tail breakpoint is chosen.
+			.minCacheablePromptLength(100_000)
+			.build();
+
+		var promptOptions = AnthropicChatOptions.builder().cacheOptions(cacheOptions).build();
+
+		List<Message> messages = List.of(new UserMessage("Original user request"), AssistantMessage.builder()
+			.content("Calling tool")
+			.toolCalls(
+					List.of(new AssistantMessage.ToolCall("call-1", "tool_use", "get_weather", "{\"city\":\"Paris\"}")))
+			.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "get_weather", "{\"temp\":20}")))
+					.build(),
+				AssistantMessage.builder().content("Calling tool again").build(),
+				ToolResponseMessage.builder()
+					.responses(
+							List.of(new ToolResponseMessage.ToolResponse("call-2", "get_time", "{\"time\":\"10:00\"}")))
+					.build(),
+				new UserMessage("Current question"));
+
+		var request = client.createRequest(new Prompt(messages, promptOptions), false);
+
+		// USER message content must not be cached (agentic skips USER for breakpoint)
+		var firstUserMessage = request.messages().get(0);
+		assertThat(firstUserMessage.role()).isEqualTo(AnthropicApi.Role.USER);
+		assertThat(firstUserMessage.content()).hasSize(1);
+		assertThat(firstUserMessage.content().get(0).cacheControl()).isNull();
+
+		// ASSISTANT tool_use blocks must not be cached for agentic
+		var assistantWithToolUse = request.messages().get(1);
+		assertThat(assistantWithToolUse.role()).isEqualTo(AnthropicApi.Role.ASSISTANT);
+		assertThat(assistantWithToolUse.content())
+			.anyMatch(cb -> cb.type() == AnthropicApi.ContentBlock.Type.TOOL_USE && cb.cacheControl() == null);
+
+		// Only the last TOOL_RESULT message should have cache_control
+		var toolResult1 = request.messages().get(2);
+		assertThat(toolResult1.role()).isEqualTo(AnthropicApi.Role.USER);
+		assertThat(toolResult1.content()).hasSize(1);
+		assertThat(toolResult1.content().get(0).type()).isEqualTo(AnthropicApi.ContentBlock.Type.TOOL_RESULT);
+		assertThat(toolResult1.content().get(0).cacheControl()).isNull();
+
+		var toolResult2 = request.messages().get(4);
+		assertThat(toolResult2.role()).isEqualTo(AnthropicApi.Role.USER);
+		assertThat(toolResult2.content()).hasSize(1);
+		assertThat(toolResult2.content().get(0).type()).isEqualTo(AnthropicApi.ContentBlock.Type.TOOL_RESULT);
+		assertThat(toolResult2.content().get(0).cacheControl()).isNotNull();
+		assertThat(toolResult2.content().get(0).cacheControl().ttl())
+			.isEqualTo(AnthropicCacheTtl.FIVE_MINUTES.getValue());
+
+		// Current user question also must not get cache_control in agentic strategy
+		var lastUserMessage = request.messages().get(5);
+		assertThat(lastUserMessage.role()).isEqualTo(AnthropicApi.Role.USER);
+		assertThat(lastUserMessage.content()).hasSize(1);
+		assertThat(lastUserMessage.content().get(0).cacheControl()).isNull();
+	}
+
+	@Test
+	void agenticToolUseMovesBreakpointToLastStableAssistantWhenDeltaIsLargeEnough() {
+		var client = AnthropicChatModel.builder()
+			.anthropicApi(AnthropicApi.builder().apiKey("TEST").build())
+			.defaultOptions(AnthropicChatOptions.builder().model("claude-3-7-sonnet-latest").build())
+			.build();
+
+		AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.AGENTIC_TOOL_USE)
+			.messageTypeTtl(MessageType.ASSISTANT, AnthropicCacheTtl.FIVE_MINUTES)
+			// Force a small threshold so the delta qualifies in test.
+			.minCacheablePromptLength(50)
+			.build();
+
+		var promptOptions = AnthropicChatOptions.builder().cacheOptions(cacheOptions).build();
+
+		String longAssistant = "A".repeat(200);
+		List<Message> messages = List.of(new UserMessage("Initial request"),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "read_file", "{\"file\":\"x\"}")))
+					.build(),
+				AssistantMessage.builder().content(longAssistant).build(), new UserMessage("Current question"));
+
+		var request = client.createRequest(new Prompt(messages, promptOptions), false);
+
+		// TOOL_RESULT should not be cached (breakpoint moved to ASSISTANT)
+		var toolResult = request.messages().get(1);
+		assertThat(toolResult.role()).isEqualTo(AnthropicApi.Role.USER);
+		assertThat(toolResult.content()).hasSize(1);
+		assertThat(toolResult.content().get(0).type()).isEqualTo(AnthropicApi.ContentBlock.Type.TOOL_RESULT);
+		assertThat(toolResult.content().get(0).cacheControl()).isNull();
+
+		// ASSISTANT text should be cached
+		var assistant = request.messages().get(2);
+		assertThat(assistant.role()).isEqualTo(AnthropicApi.Role.ASSISTANT);
+		assertThat(assistant.content()).hasSize(1);
+		assertThat(assistant.content().get(0).type()).isEqualTo(AnthropicApi.ContentBlock.Type.TEXT);
+		assertThat(assistant.content().get(0).cacheControl()).isNotNull();
+	}
+
+	@Test
+	void agenticToolUseNoCacheWhenNoToolAndNoStableAssistant() {
+		var client = AnthropicChatModel.builder()
+			.anthropicApi(AnthropicApi.builder().apiKey("TEST").build())
+			.defaultOptions(AnthropicChatOptions.builder().model("claude-3-7-sonnet-latest").build())
+			.build();
+
+		AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.AGENTIC_TOOL_USE)
+			.minCacheablePromptLength(50)
+			.build();
+
+		var promptOptions = AnthropicChatOptions.builder().cacheOptions(cacheOptions).build();
+
+		// Only USER messages and ASSISTANT with toolCalls (no TOOL, no stable ASSISTANT)
+		List<Message> messages = List.of(new UserMessage("Initial request"), AssistantMessage.builder()
+			.content("I will call a tool")
+			.toolCalls(
+					List.of(new AssistantMessage.ToolCall("call-1", "tool_use", "get_weather", "{\"city\":\"Paris\"}")))
+			.build(), new UserMessage("Current question"));
+
+		var request = client.createRequest(new Prompt(messages, promptOptions), false);
+
+		// No messages should have cache_control since there's no TOOL and no stable
+		// ASSISTANT
+		for (var msg : request.messages()) {
+			for (var content : msg.content()) {
+				assertThat(content.cacheControl()).isNull();
+			}
+		}
+	}
+
+	@Test
+	void agenticToolUseFullAgenticLoopScenario() {
+		var client = AnthropicChatModel.builder()
+			.anthropicApi(AnthropicApi.builder().apiKey("TEST").build())
+			.defaultOptions(AnthropicChatOptions.builder().model("claude-3-7-sonnet-latest").build())
+			.build();
+
+		AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.AGENTIC_TOOL_USE)
+			.messageTypeTtl(MessageType.TOOL, AnthropicCacheTtl.FIVE_MINUTES)
+			// High threshold so breakpoint stays on last TOOL
+			.minCacheablePromptLength(100_000)
+			.build();
+
+		var promptOptions = AnthropicChatOptions.builder().cacheOptions(cacheOptions).build();
+
+		// Realistic agentic loop: USER -> ASSISTANT(toolCalls) -> TOOL -> ASSISTANT(toolCalls) -> TOOL
+		List<Message> messages = List.of(new UserMessage("Analyze the codebase and find bugs"),
+				AssistantMessage.builder()
+					.content("I'll start by reading the main file")
+					.toolCalls(List
+						.of(new AssistantMessage.ToolCall("call-1", "tool_use", "read_file", "{\"path\":\"main.py\"}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(
+							new ToolResponseMessage.ToolResponse("call-1", "read_file", "def main(): print('hello')")))
+					.build(),
+				AssistantMessage.builder()
+					.content("Now I'll check the tests")
+					.toolCalls(List
+						.of(new AssistantMessage.ToolCall("call-2", "tool_use", "read_file", "{\"path\":\"test.py\"}")))
+					.build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(
+							new ToolResponseMessage.ToolResponse("call-2", "read_file", "def test_main(): assert True")))
+					.build());
+
+		var request = client.createRequest(new Prompt(messages, promptOptions), false);
+
+		// First USER - no cache
+		var userMsg = request.messages().get(0);
+		assertThat(userMsg.role()).isEqualTo(AnthropicApi.Role.USER);
+		assertThat(userMsg.content().get(0).cacheControl()).isNull();
+
+		// First ASSISTANT with toolCalls - no cache on tool_use blocks
+		var assistant1 = request.messages().get(1);
+		assertThat(assistant1.role()).isEqualTo(AnthropicApi.Role.ASSISTANT);
+		assertThat(assistant1.content()).anyMatch(cb -> cb.type() == AnthropicApi.ContentBlock.Type.TOOL_USE);
+		for (var content : assistant1.content()) {
+			if (content.type() == AnthropicApi.ContentBlock.Type.TOOL_USE) {
+				assertThat(content.cacheControl()).isNull();
+			}
+		}
+
+		// First TOOL_RESULT - no cache (not the last one)
+		var tool1 = request.messages().get(2);
+		assertThat(tool1.role()).isEqualTo(AnthropicApi.Role.USER);
+		assertThat(tool1.content().get(0).type()).isEqualTo(AnthropicApi.ContentBlock.Type.TOOL_RESULT);
+		assertThat(tool1.content().get(0).cacheControl()).isNull();
+
+		// Second ASSISTANT with toolCalls - no cache
+		var assistant2 = request.messages().get(3);
+		assertThat(assistant2.role()).isEqualTo(AnthropicApi.Role.ASSISTANT);
+		for (var content : assistant2.content()) {
+			if (content.type() == AnthropicApi.ContentBlock.Type.TOOL_USE) {
+				assertThat(content.cacheControl()).isNull();
+			}
+		}
+
+		// Last TOOL_RESULT - SHOULD have cache_control
+		var tool2 = request.messages().get(4);
+		assertThat(tool2.role()).isEqualTo(AnthropicApi.Role.USER);
+		assertThat(tool2.content().get(0).type()).isEqualTo(AnthropicApi.ContentBlock.Type.TOOL_RESULT);
+		assertThat(tool2.content().get(0).cacheControl()).isNotNull();
+		assertThat(tool2.content().get(0).cacheControl().ttl()).isEqualTo(AnthropicCacheTtl.FIVE_MINUTES.getValue());
 	}
 
 }


### PR DESCRIPTION
#### Summary

This PR introduces a new `AGENTIC_TOOL_USE` caching strategy optimized for multi-iteration tool loops (agentic mode) in the Anthropic integration. The strategy uses intelligent backward-scan breakpoint placement to maximize cache efficiency when conversation history grows with tool calls and results.

---

#### Problem

The existing `CONVERSATION_HISTORY` strategy places cache breakpoints on the last USER message. In agentic tool-use scenarios, the initial USER request is often stable while the history grows with `ASSISTANT(tool_use)` and `TOOL(tool_result)` blocks. This causes:

1. **Cache boundary doesn't advance** with the tool loop — large tool results are repeatedly processed as uncached tokens
2. **Breakpoint budget exhaustion** — forward greedy iteration may consume all 4 breakpoints on early large blocks, leaving none for the tail where they matter most
3. **Mutable USER content** (e.g., `<ENVIRONMENT>` snapshots) can cause excessive cache invalidations

---

#### Solution

##### New `AGENTIC_TOOL_USE` Strategy

A deterministic, agent-friendly breakpoint placement strategy that:

- Uses **backward-scan** to find the optimal breakpoint candidate
- **Primary target**: last `TOOL` message (tool_result)
- **Fallback**: if a stable `ASSISTANT` message (without toolCalls) exists after the last TOOL and the token delta meets the minimum cacheable threshold, the breakpoint moves to that ASSISTANT
- **Never caches USER messages** (avoids mutable content like environment snapshots)
- **Never caches TOOL_USE blocks** (assistant tool call JSON is unstable)

##### New Configuration Options in `AnthropicCacheOptions`

| Option | Description | Default |
|--------|-------------|---------|
| `minCacheablePromptLength` | Minimum token count for cache eligibility (model-specific override) | Model-based: 1024/2048/4096 |
| `tokenLengthFunction` | Function to estimate token length | `ceil(chars/4)` |

##### Backward Compatibility

- `contentLengthFunction` (default: string length in chars) remains unchanged for `messageTypeMinContentLengths` eligibility checks
- `tokenLengthFunction` is used only for agentic delta estimation and `minCacheablePromptLength` gate
- Existing configurations continue to work without modification

---

#### Key Implementation Details

##### Files Changed

- **`AnthropicCacheStrategy.java`** — Added `AGENTIC_TOOL_USE` enum value with comprehensive documentation
- **`AnthropicCacheOptions.java`** — Added `minCacheablePromptLength` and `tokenLengthFunction` configuration options
- **`CacheEligibilityResolver.java`** — Extended to support token-based planning and expose new configuration
- **`AnthropicChatModel.java`** — Implemented breakpoint planner logic:
  - `findAgenticBreakpointCandidates()` — backward-scan algorithm
  - `findLastToolIndex()` — finds last TOOL message
  - `findLastStableAssistantWithoutToolCallsIndex()` — finds stable ASSISTANT candidate
  - `estimateDeltaBetweenIndices()` — token delta estimation
  - `resolveMinCacheablePromptLength()` — model-specific threshold resolution

##### Algorithm

```
1. If no breakpoints available → return empty set
2. Find baseline = last TOOL message index (or -1 if none)
3. Find lastStableAssistant = last ASSISTANT without toolCalls that has text
4. If lastStableAssistant > baseline AND delta(baseline, lastStableAssistant) >= minCacheableDelta:
   → select lastStableAssistant
5. Else if baseline >= 0:
   → select baseline (last TOOL)
6. Apply cache_control only to selected index
```

---

#### Usage Example

```java
AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.builder()
    .strategy(AnthropicCacheStrategy.AGENTIC_TOOL_USE)
    .messageTypeTtl(MessageType.TOOL, AnthropicCacheTtl.FIVE_MINUTES)
    .minCacheablePromptLength(1024) // optional override
    .build();

AnthropicChatOptions options = AnthropicChatOptions.builder()
    .cacheOptions(cacheOptions)
    .build();
```

---

#### Tests Added

- `agenticToolUseCachesOnlyLastToolResultMessage()` — verifies only last TOOL_RESULT gets cache_control
- `agenticToolUseMovesBreakpointToLastStableAssistantWhenDeltaIsLargeEnough()` — verifies delta-based fallback to stable ASSISTANT
- `agenticToolUseNoCacheWhenNoToolAndNoStableAssistant()` — edge case: no eligible messages
- `agenticToolUseFullAgenticLoopScenario()` — realistic multi-iteration agentic loop

---