### PR TITLE
feat: Raw request passthrough for OpenAI chat (callRaw/streamRaw)

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -20,8 +20,10 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -180,7 +182,21 @@ public class OpenAiChatModel implements ChatModel {
 		return this.internalCall(requestPrompt, null);
 	}
 
+	/**
+	 * Raw passthrough variant of {@link #call(Prompt)}: forwards {@code rawBody} verbatim
+	 * to the provider (with model/stream/key overrides applied) instead of reconstructing
+	 * the request body. The response is parsed exactly as in the normal path.
+	 */
+	public ChatResponse callRaw(Prompt prompt, String rawBody) {
+		Prompt requestPrompt = buildRequestPrompt(prompt);
+		return this.internalCall(requestPrompt, null, rawBody);
+	}
+
 	public ChatResponse internalCall(Prompt prompt, ChatResponse previousChatResponse) {
+		return this.internalCall(prompt, previousChatResponse, null);
+	}
+
+	public ChatResponse internalCall(Prompt prompt, ChatResponse previousChatResponse, String rawBody) {
 
 		ChatCompletionRequest request = createRequest(prompt, false);
 
@@ -194,8 +210,10 @@ public class OpenAiChatModel implements ChatModel {
 					this.observationRegistry)
 			.observe(() -> {
 
-				ResponseEntity<ChatCompletion> completionEntity = this.retryTemplate
-					.execute(ctx -> this.openAiApi.chatCompletionEntity(request, getAdditionalHttpHeaders(prompt)));
+				ResponseEntity<ChatCompletion> completionEntity = this.retryTemplate.execute(ctx -> rawBody != null
+						? this.openAiApi.chatCompletionEntityRaw(applyOverrides(rawBody, request),
+								getAdditionalHttpHeaders(prompt))
+						: this.openAiApi.chatCompletionEntity(request, getAdditionalHttpHeaders(prompt)));
 
 				var chatCompletion = completionEntity.getBody();
 
@@ -266,7 +284,22 @@ public class OpenAiChatModel implements ChatModel {
 		return internalStream(requestPrompt, null);
 	}
 
+	/**
+	 * Raw passthrough variant of {@link #stream(Prompt)}: forwards {@code rawBody}
+	 * verbatim to the provider (with model/stream/key overrides applied) instead of
+	 * reconstructing the request body. The response stream is parsed exactly as in the
+	 * normal path.
+	 */
+	public Flux<ChatResponse> streamRaw(Prompt prompt, String rawBody) {
+		Prompt requestPrompt = buildRequestPrompt(prompt);
+		return internalStream(requestPrompt, null, rawBody);
+	}
+
 	public Flux<ChatResponse> internalStream(Prompt prompt, ChatResponse previousChatResponse) {
+		return internalStream(prompt, previousChatResponse, null);
+	}
+
+	public Flux<ChatResponse> internalStream(Prompt prompt, ChatResponse previousChatResponse, String rawBody) {
 		return Flux.deferContextual(contextView -> {
 			ChatCompletionRequest request = createRequest(prompt, true);
 
@@ -281,8 +314,10 @@ public class OpenAiChatModel implements ChatModel {
 				throw new IllegalArgumentException("Audio parameters are not supported for streaming requests.");
 			}
 
-			Flux<OpenAiApi.ChatCompletionChunk> completionChunks = this.openAiApi.chatCompletionStream(request,
-					getAdditionalHttpHeaders(prompt));
+			Flux<OpenAiApi.ChatCompletionChunk> completionChunks = rawBody != null
+					? this.openAiApi.chatCompletionStreamRaw(applyOverrides(rawBody, request),
+							getAdditionalHttpHeaders(prompt))
+					: this.openAiApi.chatCompletionStream(request, getAdditionalHttpHeaders(prompt));
 
 			// For chunked responses, only the first chunk contains the choice role.
 			// The rest of the chunks with same ID share the same role.
@@ -408,6 +443,37 @@ public class OpenAiChatModel implements ChatModel {
 		}
 		return CollectionUtils.toMultiValueMap(
 				headers.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> List.of(e.getValue()))));
+	}
+
+	/**
+	 * Applies the minimal mandatory overrides to a raw passthrough request body before
+	 * sending it verbatim: the resolved provider {@code model}, the actual transport
+	 * {@code stream} flag, and (for streaming) {@code stream_options.include_usage=true}
+	 * so the final usage chunk is emitted for billing. Everything else is forwarded
+	 * as-is.
+	 */
+	private String applyOverrides(String rawBody, ChatCompletionRequest request) {
+		try {
+			JsonNode tree = ModelOptionsUtils.OBJECT_MAPPER.readTree(rawBody);
+			if (!(tree instanceof ObjectNode root)) {
+				throw new IllegalArgumentException("Raw passthrough request body must be a JSON object");
+			}
+			if (request.model() != null) {
+				root.put("model", request.model());
+			}
+			boolean stream = Boolean.TRUE.equals(request.stream());
+			root.put("stream", stream);
+			if (stream) {
+				ObjectNode streamOptions = root.get("stream_options") instanceof ObjectNode existing ? existing
+						: ModelOptionsUtils.OBJECT_MAPPER.createObjectNode();
+				streamOptions.put("include_usage", true);
+				root.set("stream_options", streamOptions);
+			}
+			return ModelOptionsUtils.OBJECT_MAPPER.writeValueAsString(root);
+		}
+		catch (JsonProcessingException e) {
+			throw new IllegalArgumentException("Failed to apply overrides to raw passthrough request body", e);
+		}
 	}
 
 	private Generation buildGeneration(Choice choice, Map<String, Object> metadata, ChatCompletionRequest request) {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -375,7 +375,13 @@ public class OpenAiChatModel implements ChatModel {
 				.buffer(2, 1)
 				.map(bufferList -> {
 					ChatResponse firstResponse = bufferList.get(0);
-					if (request.streamOptions() != null && request.streamOptions().includeUsage()) {
+					// Raw passthrough forces stream_options.include_usage=true onto the
+					// wire body (applyOverrides), but the typed request has no
+					// streamOptions. Gate on rawBody too, else the final usage chunk is
+					// dropped and raw streams report empty token totals.
+					boolean includeUsage = rawBody != null
+							|| (request.streamOptions() != null && request.streamOptions().includeUsage());
+					if (includeUsage) {
 						if (bufferList.size() == 2) {
 							ChatResponse secondResponse = bufferList.get(1);
 							if (secondResponse != null && secondResponse.getMetadata() != null) {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -352,9 +352,10 @@ public class OpenAiApi {
 			.bodyValue(rawBody)
 			.retrieve()
 			.bodyToFlux(String.class)
-			// cancels the flux stream after the "[DONE]" is received.
-			.takeUntil(SSE_DONE_PREDICATE)
-			// filters out the "[DONE]" message.
+			// Do NOT takeUntil("[DONE]"): cancelling on the sentinel closes the
+			// connection before the body is drained, defeating the connection reuse
+			// the typed chatCompletionStream above relies on, and making the gateway
+			// drop TLS handshakes under load. Just filter [DONE] and drain to EOF.
 			.filter(SSE_DONE_PREDICATE.negate())
 			.map(parser)
 			// Detect is the chunk is part of a streaming function call.

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -225,6 +225,36 @@ public class OpenAiApi {
 	}
 
 	/**
+	 * Sends a raw, pre-serialized chat completion request body verbatim to the
+	 * completions endpoint. Used by the raw passthrough path to forward the original
+	 * client request without reconstructing it. Forwarded headers are added only when
+	 * absent so that gateway-set headers (and the injected API key) win.
+	 * @param rawBody the raw JSON request body, sent as-is.
+	 * @param additionalHttpHeader Optional, additional HTTP headers to be added to the
+	 * request only when not already present.
+	 * @return Entity response with {@link ChatCompletion} as a body and HTTP status code
+	 * and headers.
+	 */
+	public ResponseEntity<ChatCompletion> chatCompletionEntityRaw(String rawBody,
+			MultiValueMap<String, String> additionalHttpHeader) {
+
+		Assert.notNull(rawBody, REQUEST_BODY_NULL_MESSAGE);
+		Assert.notNull(additionalHttpHeader, ADDITIONAL_HEADERS_NULL_MESSAGE);
+
+		// @formatter:off
+		return this.restClient.post()
+			.uri(this.completionsPath)
+			.headers(headers -> {
+				addHeadersIfMissing(headers, additionalHttpHeader);
+				addDefaultHeadersIfMissing(headers);
+			})
+			.body(rawBody)
+			.retrieve()
+			.toEntity(ChatCompletion.class);
+		// @formatter:on
+	}
+
+	/**
 	 * Creates a streaming chat response for the given chat conversation.
 	 * @param chatRequest The chat completion request. Must have the stream property set
 	 * to true.
@@ -260,6 +290,70 @@ public class OpenAiApi {
 			.body(Mono.just(chatRequest), ChatCompletionRequest.class)
 			.retrieve()
 			.bodyToFlux(String.class)
+			// filters out the "[DONE]" message.
+			.filter(SSE_DONE_PREDICATE.negate())
+			.map(parser)
+			// Detect is the chunk is part of a streaming function call.
+			.map(chunk -> {
+				if (this.chunkMerger.isStreamingToolFunctionCall(chunk)) {
+					isInsideTool.set(true);
+				}
+				return chunk;
+			})
+			// Group all chunks belonging to the same function call.
+			// Flux<ChatCompletionChunk> -> Flux<Flux<ChatCompletionChunk>>
+			.windowUntil(chunk -> {
+				if (isInsideTool.get() && this.chunkMerger.isStreamingToolFunctionCallFinish(chunk)) {
+					isInsideTool.set(false);
+					return true;
+				}
+				return !isInsideTool.get();
+			})
+			// Merging the window chunks into a single chunk.
+			// Reduce the inner Flux<ChatCompletionChunk> window into a single
+			// Mono<ChatCompletionChunk>,
+			// Flux<Flux<ChatCompletionChunk>> -> Flux<Mono<ChatCompletionChunk>>
+			.concatMapIterable(window -> {
+				Mono<ChatCompletionChunk> monoChunk = window.reduce(
+						new ChatCompletionChunk(null, null, null, null, null, null, null, null),
+						(previous, current) -> this.chunkMerger.merge(previous, current));
+				return List.of(monoChunk);
+			})
+			// Flux<Mono<ChatCompletionChunk>> -> Flux<ChatCompletionChunk>
+			.flatMap(mono -> mono);
+	}
+
+	/**
+	 * Creates a streaming chat response from a raw, pre-serialized request body sent
+	 * verbatim to the completions endpoint. Mirrors {@link #chatCompletionStream} but
+	 * forwards the original client body without reconstructing it. Forwarded headers are
+	 * added only when absent so that gateway-set headers (and the injected API key) win.
+	 * @param rawBody the raw JSON request body, sent as-is. Must have the stream property
+	 * set to true.
+	 * @param additionalHttpHeader Optional, additional HTTP headers to be added to the
+	 * request only when not already present.
+	 * @return Returns a {@link Flux} stream from chat completion chunks.
+	 */
+	public Flux<ChatCompletionChunk> chatCompletionStreamRaw(String rawBody,
+			MultiValueMap<String, String> additionalHttpHeader) {
+
+		Assert.notNull(rawBody, REQUEST_BODY_NULL_MESSAGE);
+		Assert.notNull(additionalHttpHeader, ADDITIONAL_HEADERS_NULL_MESSAGE);
+
+		AtomicBoolean isInsideTool = new AtomicBoolean(false);
+
+		// @formatter:off
+		return this.webClient.post()
+			.uri(this.completionsPath)
+			.headers(headers -> {
+				addHeadersIfMissing(headers, additionalHttpHeader);
+				addDefaultHeadersIfMissing(headers);
+			}) // @formatter:on
+			.bodyValue(rawBody)
+			.retrieve()
+			.bodyToFlux(String.class)
+			// cancels the flux stream after the "[DONE]" is received.
+			.takeUntil(SSE_DONE_PREDICATE)
 			// filters out the "[DONE]" message.
 			.filter(SSE_DONE_PREDICATE.negate())
 			.map(parser)
@@ -340,6 +434,18 @@ public class OpenAiApi {
 		if (!headers.containsKey(HttpHeaders.AUTHORIZATION) && !(this.apiKey instanceof NoopApiKey)) {
 			headers.setBearerAuth(this.apiKey.getValue());
 		}
+	}
+
+	/**
+	 * Adds the given headers only when the key is not already present, so that headers
+	 * set earlier (defaults, gateway-managed) are never overwritten by forwarded ones.
+	 */
+	private void addHeadersIfMissing(HttpHeaders headers, MultiValueMap<String, String> additionalHttpHeader) {
+		additionalHttpHeader.forEach((key, values) -> {
+			if (!headers.containsKey(key)) {
+				headers.addAll(key, values);
+			}
+		});
 	}
 
 	// Package-private getters for mutate/copy

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelRawPassthroughIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelRawPassthroughIT.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.chat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.OpenAiTestConfiguration;
+import org.springframework.ai.retry.NonTransientAiException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Live integration tests for the OpenAI raw-passthrough send path
+ * ({@code OpenAiChatModel#callRaw} / {@code streamRaw}), driving spring-ai the same way
+ * ai-router does: a raw, pre-serialized JSON body forwarded verbatim, with the model
+ * supplied via the typed prompt options.
+ *
+ * <p>
+ * Covers the areas requested in the PR review: token counts, tool calls, provider errors,
+ * and a reasoning model. Requires {@code OPENAI_API_KEY}.
+ */
+@SpringBootTest(classes = OpenAiTestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiChatModelRawPassthroughIT {
+
+	private static final String DEFAULT_MODEL = "gpt-4o-mini";
+
+	@Autowired
+	private OpenAiChatModel openAiChatModel;
+
+	private Prompt promptWithModel(String model, String userText) {
+		return new Prompt(List.of(new UserMessage(userText)), OpenAiChatOptions.builder().model(model).build());
+	}
+
+	@Test
+	void callRawReturnsContentAndTokenCounts() {
+		String rawBody = """
+				{"messages":[{"role":"user","content":"Reply with exactly: pong"}]}
+				""";
+
+		ChatResponse response = this.openAiChatModel.callRaw(promptWithModel(DEFAULT_MODEL, "Reply with exactly: pong"),
+				rawBody);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput().getText()).isNotBlank();
+		Usage usage = response.getMetadata().getUsage();
+		assertThat(usage).isNotNull();
+		assertThat(usage.getPromptTokens()).isGreaterThan(0);
+		assertThat(usage.getCompletionTokens()).isGreaterThan(0);
+		assertThat(usage.getTotalTokens()).isGreaterThan(0);
+	}
+
+	@Test
+	void streamRawAccumulatesTokenCounts() {
+		String rawBody = """
+				{"messages":[{"role":"user","content":"Count from 1 to 5."}]}
+				""";
+
+		List<ChatResponse> responses = this.openAiChatModel
+			.streamRaw(promptWithModel(DEFAULT_MODEL, "Count from 1 to 5."), rawBody)
+			.collectList()
+			.block();
+
+		assertThat(responses).isNotNull().isNotEmpty();
+
+		String content = responses.stream()
+			.map(r -> r.getResult() != null ? r.getResult().getOutput().getText() : "")
+			.collect(Collectors.joining());
+		assertThat(content).isNotBlank();
+
+		// The final usage chunk must be accumulated even though include_usage was forced
+		// onto the raw wire body, not the typed request (the streaming-usage fix).
+		boolean anyUsage = responses.stream()
+			.map(r -> r.getMetadata().getUsage())
+			.anyMatch(u -> u != null && u.getTotalTokens() != null && u.getTotalTokens() > 0);
+		assertThat(anyUsage).isTrue();
+	}
+
+	@Test
+	void callRawSurfacesToolCallsWithoutExecutingThem() {
+		String rawBody = """
+				{
+				  "messages":[{"role":"user","content":"What is the weather in Paris? Use the tool."}],
+				  "tools":[{"type":"function","function":{
+				    "name":"get_weather",
+				    "description":"Get the current weather for a city",
+				    "parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
+				  }}],
+				  "tool_choice":"required"
+				}
+				""";
+
+		// No tool callbacks + internal tool execution disabled: the raw path must forward
+		// the tool call to the caller (like ai-router), not execute it locally.
+		Prompt prompt = new Prompt(List.of(new UserMessage("What is the weather in Paris? Use the tool.")),
+				OpenAiChatOptions.builder().model(DEFAULT_MODEL).internalToolExecutionEnabled(false).build());
+
+		ChatResponse response = this.openAiChatModel.callRaw(prompt, rawBody);
+
+		assertThat(response).isNotNull();
+		assertThat(response.hasToolCalls()).isTrue();
+		assertThat(response.getResult().getOutput().getToolCalls().get(0).name()).isEqualTo("get_weather");
+	}
+
+	@Test
+	void callRawPropagatesProviderError() {
+		// temperature 5 is out of OpenAI's accepted [0,2] range -> 400 from the provider.
+		String rawBody = """
+				{"messages":[{"role":"user","content":"hi"}],"temperature":5}
+				""";
+
+		assertThatThrownBy(() -> this.openAiChatModel.callRaw(promptWithModel(DEFAULT_MODEL, "hi"), rawBody))
+			.isInstanceOf(NonTransientAiException.class);
+	}
+
+	@Test
+	void callRawWorksForReasoningModel() {
+		// A reasoning model has different parameter rules (no temperature, uses
+		// max_completion_tokens); this is a smoke test that the raw path forwards such a
+		// request without choking and still reports usage.
+		String rawBody = """
+				{"messages":[{"role":"user","content":"What is 17 + 25? Reply with just the number."}]}
+				""";
+
+		ChatResponse response = this.openAiChatModel.callRaw(promptWithModel("o4-mini", "What is 17 + 25?"), rawBody);
+
+		assertThat(response).isNotNull();
+		assertThat(StringUtils.hasText(response.getResult().getOutput().getText())).isTrue();
+		assertThat(response.getMetadata().getUsage().getTotalTokens()).isGreaterThan(0);
+	}
+
+}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelRawPassthroughTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelRawPassthroughTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.chat;
+
+import java.util.List;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionChunk;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit test for the OpenAI raw-passthrough streaming path ({@code streamRaw}).
+ *
+ * <p>
+ * Regression guard for the streaming-usage accounting bug: on the raw path
+ * {@code applyOverrides} forces {@code include_usage=true} onto the wire body, but the
+ * typed {@code ChatCompletionRequest} it derives from has no {@code streamOptions}. The
+ * usage-merge gate must therefore key off the raw body, not the typed request, or the
+ * final usage chunk is dropped and token totals come out empty.
+ */
+@ExtendWith(MockitoExtension.class)
+public class OpenAiChatModelRawPassthroughTests {
+
+	@Mock
+	private OpenAiApi openAiApi;
+
+	private OpenAiChatModel chatModel;
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		// Default options carry no streamOptions, mirroring how ai-router drives the raw
+		// path: include_usage lives only in the raw body, never in the typed request.
+		this.chatModel = new OpenAiChatModel(this.openAiApi, OpenAiChatOptions.builder().build(), toolCallingManager,
+				retryTemplate, observationRegistry);
+	}
+
+	@Test
+	void streamRawAccumulatesUsageEvenWhenTypedStreamOptionsAreAbsent() {
+		setupChatModel();
+
+		// A content chunk (no usage) followed by the final usage-only chunk OpenAI emits
+		// when stream_options.include_usage=true — exactly what applyOverrides forces.
+		var contentChoice = new ChunkChoice(null, 0, new ChatCompletionMessage("Hello", Role.ASSISTANT), null);
+		ChatCompletionChunk contentChunk = new ChatCompletionChunk("id", List.of(contentChoice), 666L, "model", null,
+				null, "chat.completion.chunk", null);
+		ChatCompletionChunk usageChunk = new ChatCompletionChunk("id", List.of(), 666L, "model", null, null,
+				"chat.completion.chunk", new OpenAiApi.Usage(12, 9, 21));
+
+		given(this.openAiApi.chatCompletionStreamRaw(anyString(), any()))
+			.willReturn(Flux.just(contentChunk, usageChunk));
+
+		// A minimal valid JSON object is enough — applyOverrides only needs to parse it.
+		List<ChatResponse> responses = this.chatModel.streamRaw(new Prompt("test"), "{\"messages\":[]}")
+			.collectList()
+			.block();
+
+		assertThat(responses).isNotEmpty();
+
+		// The usage from the final chunk must be merged onto the content response, just
+		// like the typed streaming path. Before the fix the gate read the (null) typed
+		// streamOptions, so the content response carried an empty usage.
+		ChatResponse contentResponse = responses.stream()
+			.filter(r -> r.getResult() != null && StringUtils.hasText(r.getResult().getOutput().getText()))
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("no response carried the assistant text"));
+
+		Usage usage = contentResponse.getMetadata().getUsage();
+		assertThat(usage).isNotNull();
+		assertThat(usage.getPromptTokens()).isEqualTo(9);
+		assertThat(usage.getCompletionTokens()).isEqualTo(12);
+		assertThat(usage.getTotalTokens()).isEqualTo(21);
+	}
+
+}


### PR DESCRIPTION
## What

Add a raw-request passthrough path to the OpenAI chat model so a caller can
forward an already-serialized OpenAI chat-completions request body (and selected
headers) verbatim to the upstream, instead of re-serializing from the typed
options. The response is still parsed normally.

## Changes

- `OpenAiApi`: `chatCompletionEntityRaw(String rawBody, MultiValueMap headers)` and
  `chatCompletionStreamRaw(...)`, mirroring the typed calls but sending the raw body
  and adding caller headers if missing (then default headers if still missing).
- `OpenAiChatModel`: `callRaw` / `streamRaw` + a 3-arg `internalCall` / `internalStream`
  that carries the raw body (2-arg path delegates with `null`; tool-call recursion stays
  on the typed path). `applyOverrides` re-applies `model`, `stream`, and
  `stream_options.include_usage` from the request onto the raw body.
