### PR TITLE
feat: Raw request passthrough for Anthropic chat (callRaw/streamRaw)

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -25,7 +25,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -184,7 +187,27 @@ public class AnthropicChatModel implements ChatModel {
 		return this.internalCall(requestPrompt, null);
 	}
 
+	/**
+	 * Raw passthrough variant of {@link #call(Prompt)}: forwards {@code rawBody} verbatim
+	 * to the provider (with model/stream overrides applied, and max_tokens injected only
+	 * when absent) instead of reconstructing the request body. The response is parsed
+	 * exactly as in the normal path, so raw bodies that elicit content block types the
+	 * typed response pipeline does not understand (e.g. server tools such as web_search)
+	 * are not supported. Callers must disable internal tool execution
+	 * ({@code internalToolExecutionEnabled=false}): the raw body is not re-forwarded
+	 * across tool-execution hops, so a tool-execution round-trip would silently fall back
+	 * to a reconstructed typed request.
+	 */
+	public ChatResponse callRaw(Prompt prompt, String rawBody) {
+		Prompt requestPrompt = buildRequestPrompt(prompt);
+		return this.internalCall(requestPrompt, null, rawBody);
+	}
+
 	public ChatResponse internalCall(Prompt prompt, ChatResponse previousChatResponse) {
+		return this.internalCall(prompt, previousChatResponse, null);
+	}
+
+	public ChatResponse internalCall(Prompt prompt, ChatResponse previousChatResponse, String rawBody) {
 		ChatCompletionRequest request = createRequest(prompt, false);
 
 		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
@@ -197,8 +220,11 @@ public class AnthropicChatModel implements ChatModel {
 					this.observationRegistry)
 			.observe(() -> {
 
-				ResponseEntity<ChatCompletionResponse> completionEntity = this.retryTemplate.execute(
-						ctx -> this.anthropicApi.chatCompletionEntity(request, this.getAdditionalHttpHeaders(prompt)));
+				ResponseEntity<ChatCompletionResponse> completionEntity = this.retryTemplate
+					.execute(ctx -> rawBody != null
+							? this.anthropicApi.chatCompletionEntityRaw(applyOverrides(rawBody, request),
+									this.getAdditionalHttpHeaders(prompt))
+							: this.anthropicApi.chatCompletionEntity(request, this.getAdditionalHttpHeaders(prompt)));
 
 				AnthropicApi.ChatCompletionResponse completionResponse = completionEntity.getBody();
 				AnthropicApi.Usage usage = completionResponse.usage();
@@ -247,7 +273,24 @@ public class AnthropicChatModel implements ChatModel {
 		return this.internalStream(requestPrompt, null);
 	}
 
+	/**
+	 * Raw passthrough variant of {@link #stream(Prompt)}: forwards {@code rawBody}
+	 * verbatim to the provider (with model/stream overrides applied, and max_tokens
+	 * injected only when absent) instead of reconstructing the request body. The response
+	 * stream is parsed exactly as in the normal path — see
+	 * {@link #callRaw(Prompt, String)} for the resulting limitations (unsupported content
+	 * block types, internal tool execution must be disabled by the caller).
+	 */
+	public Flux<ChatResponse> streamRaw(Prompt prompt, String rawBody) {
+		Prompt requestPrompt = buildRequestPrompt(prompt);
+		return this.internalStream(requestPrompt, null, rawBody);
+	}
+
 	public Flux<ChatResponse> internalStream(Prompt prompt, ChatResponse previousChatResponse) {
+		return this.internalStream(prompt, previousChatResponse, null);
+	}
+
+	public Flux<ChatResponse> internalStream(Prompt prompt, ChatResponse previousChatResponse, String rawBody) {
 		return Flux.deferContextual(contextView -> {
 			ChatCompletionRequest request = createRequest(prompt, true);
 
@@ -260,10 +303,14 @@ public class AnthropicChatModel implements ChatModel {
 					this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
 					this.observationRegistry);
 
-			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
+			// Build the (lazy) response flux before starting the observation so that a
+			// synchronous applyOverrides failure cannot leak a started observation.
+			Flux<ChatCompletionResponse> response = rawBody != null
+					? this.anthropicApi.chatCompletionStreamRaw(applyOverrides(rawBody, request),
+							this.getAdditionalHttpHeaders(prompt))
+					: this.anthropicApi.chatCompletionStream(request, this.getAdditionalHttpHeaders(prompt));
 
-			Flux<ChatCompletionResponse> response = this.anthropicApi.chatCompletionStream(request,
-					this.getAdditionalHttpHeaders(prompt));
+			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
 
 			// @formatter:off
 			Flux<ChatResponse> chatResponseFlux = response.flatMap(chatCompletionResponse -> {
@@ -535,6 +582,35 @@ public class AnthropicChatModel implements ChatModel {
 		}
 		return CollectionUtils.toMultiValueMap(
 				headers.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> List.of(e.getValue()))));
+	}
+
+	/**
+	 * Applies the minimal mandatory overrides to a raw passthrough request body before
+	 * sending it verbatim: the resolved provider {@code model} and the actual transport
+	 * {@code stream} flag. {@code max_tokens} is REQUIRED by the Anthropic Messages API,
+	 * so it is injected from the typed request only when the raw body does not carry it —
+	 * the client's own value is never overridden (passthrough semantics). Anthropic
+	 * always emits usage in streaming responses, so there is no include_usage analog.
+	 * Everything else is forwarded as-is.
+	 */
+	private String applyOverrides(String rawBody, ChatCompletionRequest request) {
+		try {
+			JsonNode tree = ModelOptionsUtils.OBJECT_MAPPER.readTree(rawBody);
+			if (!(tree instanceof ObjectNode root)) {
+				throw new IllegalArgumentException("Raw passthrough request body must be a JSON object");
+			}
+			if (request.model() != null) {
+				root.put("model", request.model());
+			}
+			root.put("stream", Boolean.TRUE.equals(request.stream()));
+			if (!root.hasNonNull("max_tokens") && request.maxTokens() != null) {
+				root.put("max_tokens", request.maxTokens());
+			}
+			return ModelOptionsUtils.OBJECT_MAPPER.writeValueAsString(root);
+		}
+		catch (JsonProcessingException e) {
+			throw new IllegalArgumentException("Failed to apply overrides to raw passthrough request body", e);
+		}
 	}
 
 	Prompt buildRequestPrompt(Prompt prompt) {

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -186,6 +186,38 @@ public final class AnthropicApi {
 	}
 
 	/**
+	 * Sends a raw, pre-serialized message request body verbatim to the completions
+	 * endpoint. Used by the raw passthrough path to forward the original client request
+	 * without reconstructing it. Forwarded headers are added as request-level headers, so
+	 * they shadow the client's default headers (e.g. anthropic-version, anthropic-beta)
+	 * and suppress the lazily injected API key — stripping sensitive headers such as
+	 * x-api-key is the calling gateway's responsibility.
+	 * @param rawBody the raw JSON request body, sent as-is.
+	 * @param additionalHttpHeader Optional, additional HTTP headers to be added to the
+	 * request only when not already present.
+	 * @return Entity response with {@link ChatCompletionResponse} as a body and HTTP
+	 * status code and headers.
+	 */
+	public ResponseEntity<ChatCompletionResponse> chatCompletionEntityRaw(String rawBody,
+			MultiValueMap<String, String> additionalHttpHeader) {
+
+		Assert.notNull(rawBody, "The request body can not be null.");
+		Assert.notNull(additionalHttpHeader, "The additional HTTP headers can not be null.");
+
+		// @formatter:off
+		return this.restClient.post()
+			.uri(this.completionsPath)
+			.headers(headers -> {
+				addHeadersIfMissing(headers, additionalHttpHeader);
+				addDefaultHeadersIfMissing(headers);
+			})
+			.body(rawBody)
+			.retrieve()
+			.toEntity(ChatCompletionResponse.class);
+		// @formatter:on
+	}
+
+	/**
 	 * Creates a streaming chat response for the given chat conversation.
 	 * @param chatRequest The chat completion request. Must have the stream property set
 	 * to true.
@@ -209,13 +241,8 @@ public final class AnthropicApi {
 		Assert.isTrue(chatRequest.stream(), "Request must set the stream property to true.");
 		Assert.notNull(additionalHttpHeader, "The additional HTTP headers can not be null.");
 
-		AtomicBoolean isInsideTool = new AtomicBoolean(false);
-
-		AtomicReference<ChatCompletionResponseBuilder> chatCompletionReference = new AtomicReference<>(
-				new ChatCompletionResponseBuilder());
-
 		// @formatter:off
-		return this.webClient.post()
+		Flux<String> sseLines = this.webClient.post()
 			.uri(this.completionsPath)
 			.headers(headers -> {
 				headers.addAll(additionalHttpHeader);
@@ -223,7 +250,59 @@ public final class AnthropicApi {
 			}) // @formatter:off
 			.body(Mono.just(chatRequest), ChatCompletionRequest.class)
 			.retrieve()
-			.bodyToFlux(String.class)
+			.bodyToFlux(String.class);
+
+		return parseChatCompletionStream(sseLines);
+	}
+
+	/**
+	 * Creates a streaming chat response from a raw, pre-serialized request body sent
+	 * verbatim to the completions endpoint. Mirrors {@link #chatCompletionStream} but
+	 * forwards the original client body without reconstructing it. Forwarded headers are
+	 * added as request-level headers, so they shadow the client's default headers (e.g.
+	 * anthropic-version, anthropic-beta) and suppress the lazily injected API key —
+	 * stripping sensitive headers such as x-api-key is the calling gateway's
+	 * responsibility.
+	 * @param rawBody the raw JSON request body, sent as-is. Must have the stream property
+	 * set to true.
+	 * @param additionalHttpHeader Optional, additional HTTP headers to be added to the
+	 * request only when not already present.
+	 * @return Returns a {@link Flux} stream from chat completion chunks.
+	 */
+	public Flux<ChatCompletionResponse> chatCompletionStreamRaw(String rawBody,
+			MultiValueMap<String, String> additionalHttpHeader) {
+
+		Assert.notNull(rawBody, "The request body can not be null.");
+		Assert.notNull(additionalHttpHeader, "The additional HTTP headers can not be null.");
+
+		// @formatter:off
+		Flux<String> sseLines = this.webClient.post()
+			.uri(this.completionsPath)
+			.headers(headers -> {
+				addHeadersIfMissing(headers, additionalHttpHeader);
+				addDefaultHeadersIfMissing(headers);
+			}) // @formatter:on
+			.bodyValue(rawBody)
+			.retrieve()
+			.bodyToFlux(String.class);
+
+		return parseChatCompletionStream(sseLines);
+	}
+
+	/**
+	 * Shared SSE parsing pipeline for the typed and raw streaming paths: parses
+	 * {@link StreamEvent}s, drops pings, merges tool-use event windows and assembles
+	 * {@link ChatCompletionResponse} chunks.
+	 */
+	private Flux<ChatCompletionResponse> parseChatCompletionStream(Flux<String> sseLines) {
+
+		AtomicBoolean isInsideTool = new AtomicBoolean(false);
+
+		AtomicReference<ChatCompletionResponseBuilder> chatCompletionReference = new AtomicReference<>(
+				new ChatCompletionResponseBuilder());
+
+		// @formatter:off
+		return sseLines
 			.takeUntil(SSE_DONE_PREDICATE)
 			.filter(SSE_DONE_PREDICATE.negate())
 			.map(content -> ModelOptionsUtils.jsonToObject(content, StreamEvent.class))
@@ -254,6 +333,7 @@ public final class AnthropicApi {
 			.flatMap(mono -> mono)
 			.map(event -> this.streamHelper.eventToChatCompletionResponse(event, chatCompletionReference))
 			.filter(chatCompletionResponse -> chatCompletionResponse.type() != null);
+		// @formatter:on
 	}
 
 	private void addDefaultHeadersIfMissing(HttpHeaders headers) {
@@ -263,6 +343,21 @@ public final class AnthropicApi {
 				headers.add(HEADER_X_API_KEY, apiKeyValue);
 			}
 		}
+	}
+
+	/**
+	 * Adds the given headers only when the key is not already present in the
+	 * request-level headers. Note that the request headers start out empty, so forwarded
+	 * headers land first: they shadow the client's default headers and suppress the
+	 * lazily injected API key. Guarding auth headers (x-api-key etc.) is the calling
+	 * gateway's responsibility.
+	 */
+	private void addHeadersIfMissing(HttpHeaders headers, MultiValueMap<String, String> additionalHttpHeader) {
+		additionalHttpHeader.forEach((key, values) -> {
+			if (!headers.containsKey(key)) {
+				headers.addAll(key, values);
+			}
+		});
 	}
 
 	/**

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -1489,6 +1489,12 @@ public final class AnthropicApi {
 	 *
 	 * @param inputTokens The number of input tokens which were used.
 	 * @param outputTokens The number of output tokens which were used. completion).
+	 * @param price Optional price of the request as a string. Not part of the native
+	 * Anthropic API: OpenAI-compatible gateways serving the Anthropic dialect (e.g.
+	 * OhMyCode) inject it into the terminal usage block, mirroring the OpenAI surface.
+	 * @param priceWithDiscount Optional price of the request with discount applied, as a
+	 * string. Same gateway extension as {@code price}; when present it is the canonical
+	 * billing cost.
 	 */
 	@JsonInclude(Include.NON_NULL)
 	@JsonIgnoreProperties(ignoreUnknown = true)
@@ -1497,8 +1503,15 @@ public final class AnthropicApi {
 		@JsonProperty("input_tokens") Integer inputTokens,
 		@JsonProperty("output_tokens") Integer outputTokens,
 		@JsonProperty("cache_creation_input_tokens") Integer cacheCreationInputTokens,
-		@JsonProperty("cache_read_input_tokens") Integer cacheReadInputTokens) {
+		@JsonProperty("cache_read_input_tokens") Integer cacheReadInputTokens,
+		@JsonProperty("price") String price,
+		@JsonProperty("price_with_discount") String priceWithDiscount) {
 		// @formatter:off
+
+		public Usage(Integer inputTokens, Integer outputTokens, Integer cacheCreationInputTokens,
+				Integer cacheReadInputTokens) {
+			this(inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens, null, null);
+		}
 	}
 
 	 /// ECB STOP
@@ -1793,7 +1806,13 @@ public final class AnthropicApi {
 		@JsonInclude(Include.NON_NULL)
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record MessageDeltaUsage(
-			@JsonProperty("output_tokens") Integer outputTokens) {
+			@JsonProperty("output_tokens") Integer outputTokens,
+			@JsonProperty("price") String price,
+			@JsonProperty("price_with_discount") String priceWithDiscount) {
+
+			public MessageDeltaUsage(Integer outputTokens) {
+				this(outputTokens, null, null);
+			}
 		}
 	}
 	// @formatter:on

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -303,7 +303,12 @@ public final class AnthropicApi {
 
 		// @formatter:off
 		return sseLines
-			.takeUntil(SSE_DONE_PREDICATE)
+			// Do NOT takeUntil("[DONE]"): cancelling on the sentinel closes the
+			// connection before the body is drained, defeating connection reuse and
+			// making the gateway drop TLS handshakes under load (see OpenAiApi). The
+			// native Anthropic protocol has no "[DONE]" sentinel, but an
+			// OpenAI-compatible gateway serving this dialect may emit one, so it is
+			// still filtered out. The stream is drained to EOF.
 			.filter(SSE_DONE_PREDICATE.negate())
 			.map(content -> ModelOptionsUtils.jsonToObject(content, StreamEvent.class))
 			.filter(event -> event.type() != EventType.PING)

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
@@ -210,10 +210,13 @@ public class StreamHelper {
 			}
 
 			if (messageDeltaEvent.usage() != null) {
+				// Gateway pricing extension: OpenAI-compatible gateways (e.g. OhMyCode)
+				// inject price/price_with_discount into the terminal message_delta usage.
 				Usage totalUsage = new Usage(contentBlockReference.get().usage.inputTokens(),
 						messageDeltaEvent.usage().outputTokens(),
 						contentBlockReference.get().usage.cacheCreationInputTokens(),
-						contentBlockReference.get().usage.cacheReadInputTokens());
+						contentBlockReference.get().usage.cacheReadInputTokens(), messageDeltaEvent.usage().price(),
+						messageDeltaEvent.usage().priceWithDiscount());
 				contentBlockReference.get().withUsage(totalUsage);
 			}
 		}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelRawPassthroughIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelRawPassthroughIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Live integration tests for the Anthropic raw-passthrough send path
+ * ({@code AnthropicChatModel#callRaw} / {@code streamRaw}), driving spring-ai the same
+ * way ai-router does: a raw, pre-serialized JSON body forwarded verbatim, with the model
+ * supplied via the typed prompt options.
+ *
+ * <p>
+ * Covers token counts, tool calls and provider errors on the raw path. Requires
+ * {@code ANTHROPIC_API_KEY}.
+ */
+@SpringBootTest(classes = AnthropicTestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+class AnthropicChatModelRawPassthroughIT {
+
+	private static final String DEFAULT_MODEL = "claude-3-5-haiku-latest";
+
+	@Autowired
+	private AnthropicChatModel anthropicChatModel;
+
+	private Prompt promptWithModel(String model, String userText) {
+		return new Prompt(List.of(new UserMessage(userText)), AnthropicChatOptions.builder().model(model).build());
+	}
+
+	@Test
+	void callRawReturnsContentAndTokenCounts() {
+		String rawBody = """
+				{"messages":[{"role":"user","content":"Reply with exactly: pong"}],"max_tokens":64}
+				""";
+
+		ChatResponse response = this.anthropicChatModel
+			.callRaw(promptWithModel(DEFAULT_MODEL, "Reply with exactly: pong"), rawBody);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput().getText()).isNotBlank();
+		Usage usage = response.getMetadata().getUsage();
+		assertThat(usage).isNotNull();
+		assertThat(usage.getPromptTokens()).isGreaterThan(0);
+		assertThat(usage.getCompletionTokens()).isGreaterThan(0);
+	}
+
+	@Test
+	void callRawInjectsMaxTokensWhenAbsent() {
+		// Anthropic rejects requests without max_tokens; the raw path must inject the
+		// gateway default when the client body omits it.
+		String rawBody = """
+				{"messages":[{"role":"user","content":"Reply with exactly: pong"}]}
+				""";
+
+		ChatResponse response = this.anthropicChatModel
+			.callRaw(promptWithModel(DEFAULT_MODEL, "Reply with exactly: pong"), rawBody);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput().getText()).isNotBlank();
+	}
+
+	@Test
+	void streamRawAccumulatesTokenCounts() {
+		String rawBody = """
+				{"messages":[{"role":"user","content":"Count from 1 to 5."}],"max_tokens":256}
+				""";
+
+		List<ChatResponse> responses = this.anthropicChatModel
+			.streamRaw(promptWithModel(DEFAULT_MODEL, "Count from 1 to 5."), rawBody)
+			.collectList()
+			.block();
+
+		assertThat(responses).isNotNull().isNotEmpty();
+
+		String content = responses.stream()
+			.map(r -> r.getResult() != null && r.getResult().getOutput().getText() != null
+					? r.getResult().getOutput().getText() : "")
+			.collect(Collectors.joining());
+		assertThat(content).isNotBlank();
+
+		// Usage arrives via message_start (input) and message_delta (output) and must be
+		// accumulated on the raw path just like on the typed one.
+		boolean anyUsage = responses.stream()
+			.map(r -> r.getMetadata().getUsage())
+			.anyMatch(u -> u != null && u.getPromptTokens() != null && u.getPromptTokens() > 0
+					&& u.getCompletionTokens() != null && u.getCompletionTokens() > 0);
+		assertThat(anyUsage).isTrue();
+	}
+
+	@Test
+	void callRawSurfacesToolCallsWithoutExecutingThem() {
+		String rawBody = """
+				{
+				  "messages":[{"role":"user","content":"What is the weather in Paris? Use the tool."}],
+				  "max_tokens":512,
+				  "tools":[{
+				    "name":"get_weather",
+				    "description":"Get the current weather for a city",
+				    "input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
+				  }],
+				  "tool_choice":{"type":"any"}
+				}
+				""";
+
+		// No tool callbacks + internal tool execution disabled: the raw path must forward
+		// the tool call to the caller (like ai-router), not execute it locally.
+		Prompt prompt = new Prompt(List.of(new UserMessage("What is the weather in Paris? Use the tool.")),
+				AnthropicChatOptions.builder().model(DEFAULT_MODEL).internalToolExecutionEnabled(false).build());
+
+		ChatResponse response = this.anthropicChatModel.callRaw(prompt, rawBody);
+
+		assertThat(response).isNotNull();
+		assertThat(response.hasToolCalls()).isTrue();
+		assertThat(response.getResult().getOutput().getToolCalls().get(0).name()).isEqualTo("get_weather");
+	}
+
+	@Test
+	void callRawPropagatesProviderError() {
+		// temperature 5 is out of Anthropic's accepted [0,1] range -> 400 from the
+		// provider.
+		String rawBody = """
+				{"messages":[{"role":"user","content":"hi"}],"max_tokens":64,"temperature":5}
+				""";
+
+		assertThatThrownBy(() -> this.anthropicChatModel.callRaw(promptWithModel(DEFAULT_MODEL, "hi"), rawBody))
+			.isInstanceOf(RuntimeException.class);
+	}
+
+}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelRawPassthroughTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelRawPassthroughTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionResponse;
+import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock;
+import org.springframework.ai.anthropic.api.AnthropicApi.Role;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for the Anthropic raw-passthrough path ({@code callRaw} /
+ * {@code streamRaw}): the raw body must be forwarded with only {@code model} and
+ * {@code stream} overridden, {@code max_tokens} injected only when absent, and every
+ * other field (including vendor extensions) preserved verbatim.
+ */
+@ExtendWith(MockitoExtension.class)
+public class AnthropicChatModelRawPassthroughTests {
+
+	private static final String MODEL = "claude-sonnet-4-5";
+
+	@Mock
+	private AnthropicApi anthropicApi;
+
+	private AnthropicChatModel chatModel;
+
+	private void setupChatModel() {
+		this.chatModel = AnthropicChatModel.builder()
+			.anthropicApi(this.anthropicApi)
+			.defaultOptions(AnthropicChatOptions.builder().model(MODEL).maxTokens(4096).build())
+			.build();
+	}
+
+	private static ChatCompletionResponse completionResponse() {
+		return new ChatCompletionResponse("msg_1", "message", Role.ASSISTANT, List.of(new ContentBlock("Hello there")),
+				MODEL, "end_turn", null, new AnthropicApi.Usage(9, 12, null, null));
+	}
+
+	@Test
+	void callRawForwardsBodyWithOverridesAndPreservesClientFields() throws Exception {
+		setupChatModel();
+
+		ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+		given(this.anthropicApi.chatCompletionEntityRaw(bodyCaptor.capture(), any()))
+			.willReturn(ResponseEntity.ok(completionResponse()));
+
+		String rawBody = """
+				{"model":"client-model","max_tokens":777,"stream":true,
+				 "messages":[{"role":"user","content":"raw hello"}],
+				 "vendor_extension":{"keep":"me"}}""";
+
+		ChatResponse response = this.chatModel.callRaw(new Prompt("typed prompt"), rawBody);
+
+		JsonNode sent = ModelOptionsUtils.OBJECT_MAPPER.readTree(bodyCaptor.getValue());
+		// Gateway-owned overrides.
+		assertThat(sent.get("model").asText()).isEqualTo(MODEL);
+		assertThat(sent.get("stream").asBoolean()).isFalse();
+		// Client fields preserved verbatim.
+		assertThat(sent.get("max_tokens").asInt()).isEqualTo(777);
+		assertThat(sent.get("messages").get(0).get("content").asText()).isEqualTo("raw hello");
+		assertThat(sent.get("vendor_extension").get("keep").asText()).isEqualTo("me");
+
+		assertThat(response.getResult().getOutput().getText()).isEqualTo("Hello there");
+		Usage usage = response.getMetadata().getUsage();
+		assertThat(usage.getPromptTokens()).isEqualTo(9);
+		assertThat(usage.getCompletionTokens()).isEqualTo(12);
+	}
+
+	@Test
+	void callRawInjectsMaxTokensOnlyWhenAbsent() throws Exception {
+		setupChatModel();
+
+		ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+		given(this.anthropicApi.chatCompletionEntityRaw(bodyCaptor.capture(), any()))
+			.willReturn(ResponseEntity.ok(completionResponse()));
+
+		this.chatModel.callRaw(new Prompt("typed prompt"), "{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}");
+
+		JsonNode sent = ModelOptionsUtils.OBJECT_MAPPER.readTree(bodyCaptor.getValue());
+		// Anthropic requires max_tokens; the gateway default fills the gap.
+		assertThat(sent.get("max_tokens").asInt()).isEqualTo(4096);
+	}
+
+	@Test
+	void streamRawForwardsBodyWithStreamTrueAndParsesUsage() throws Exception {
+		setupChatModel();
+
+		ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+		given(this.anthropicApi.chatCompletionStreamRaw(bodyCaptor.capture(), any()))
+			.willReturn(Flux.just(completionResponse()));
+
+		String rawBody = "{\"model\":\"client-model\",\"max_tokens\":100,\"messages\":[]}";
+		List<ChatResponse> responses = this.chatModel.streamRaw(new Prompt("typed prompt"), rawBody)
+			.collectList()
+			.block();
+
+		JsonNode sent = ModelOptionsUtils.OBJECT_MAPPER.readTree(bodyCaptor.getValue());
+		assertThat(sent.get("model").asText()).isEqualTo(MODEL);
+		assertThat(sent.get("stream").asBoolean()).isTrue();
+		assertThat(sent.get("max_tokens").asInt()).isEqualTo(100);
+
+		assertThat(responses).isNotEmpty();
+		ChatResponse last = responses.get(responses.size() - 1);
+		Usage usage = last.getMetadata().getUsage();
+		assertThat(usage.getPromptTokens()).isEqualTo(9);
+		assertThat(usage.getCompletionTokens()).isEqualTo(12);
+	}
+
+	@Test
+	void callRawRejectsNonObjectBody() {
+		setupChatModel();
+
+		assertThatThrownBy(() -> this.chatModel.callRaw(new Prompt("typed prompt"), "[1,2,3]"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("JSON object");
+	}
+
+	@Test
+	void callRawRejectsMalformedBody() {
+		setupChatModel();
+
+		assertThatThrownBy(() -> this.chatModel.callRaw(new Prompt("typed prompt"), "{not json"))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/StreamHelperTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/StreamHelperTests.java
@@ -194,6 +194,34 @@ class StreamHelperTests {
 	}
 
 	@Test
+	void testMessageDeltaEventCarriesGatewayPricing() {
+		StreamHelper streamHelper = new StreamHelper();
+		AtomicReference<ChatCompletionResponseBuilder> contentBlockReference = new AtomicReference<>();
+
+		Usage usage = new Usage(100, 0, 30, 50);
+		ChatCompletionResponse initialMessage = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT,
+				List.of(), "claude-3-5-sonnet", null, null, usage);
+		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, initialMessage);
+		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
+
+		// OpenAI-compatible gateways (e.g. OhMyCode) inject price/price_with_discount
+		// into the terminal message_delta usage block; they must survive the merge.
+		MessageDeltaEvent.MessageDelta delta = new MessageDeltaEvent.MessageDelta("end_turn", null);
+		MessageDeltaEvent.MessageDeltaUsage deltaUsage = new MessageDeltaEvent.MessageDeltaUsage(15, "0.0123",
+				"0.0045");
+		MessageDeltaEvent deltaEvent = new MessageDeltaEvent(AnthropicApi.EventType.MESSAGE_DELTA, delta, deltaUsage);
+
+		ChatCompletionResponse response = streamHelper.eventToChatCompletionResponse(deltaEvent, contentBlockReference);
+
+		assertThat(response.usage().outputTokens()).isEqualTo(15);
+		// Token counts from message_start survive alongside the injected pricing.
+		assertThat(response.usage().inputTokens()).isEqualTo(100);
+		assertThat(response.usage().cacheReadInputTokens()).isEqualTo(50);
+		assertThat(response.usage().price()).isEqualTo("0.0123");
+		assertThat(response.usage().priceWithDiscount()).isEqualTo("0.0045");
+	}
+
+	@Test
 	void testPingEvent() {
 		StreamHelper streamHelper = new StreamHelper();
 		AtomicReference<ChatCompletionResponseBuilder> contentBlockReference = new AtomicReference<>();


### PR DESCRIPTION
Mirrors the merged OpenAI raw passthrough (#42) for the Anthropic dialect: the gateway can forward the client's original JSON body verbatim to `api.anthropic.com/v1/messages` instead of reconstructing it from typed DTOs.

## Changes

**AnthropicApi**
- `chatCompletionEntityRaw(String rawBody, headers)` / `chatCompletionStreamRaw(...)` — send the raw body as-is; forwarded per-request headers shadow client defaults (so a client-supplied `anthropic-beta` overrides the gateway default — deliberate; auth headers like `x-api-key` must be stripped by the calling gateway's denylist, documented in javadoc).
- The typed streaming path's SSE pipeline is extracted into a shared private `parseChatCompletionStream` — behavior unchanged.

**AnthropicChatModel**
- Public `callRaw` / `streamRaw` + `applyOverrides`: only `model` and `stream` are overridden; `max_tokens` is injected only when absent (Anthropic requires it); everything else, including vendor extensions, is preserved verbatim. Non-object / malformed bodies are rejected with `IllegalArgumentException`.
- Unlike the OpenAI path, no `include_usage` handling is needed: Anthropic always reports usage via `message_start`/`message_delta`. No `[DONE]` drain handling either — Anthropic streams end at natural EOF.
- Raw body is not re-forwarded across tool-execution hops; callers must set `internalToolExecutionEnabled=false` (ai-router already does).

## Tests
- `AnthropicChatModelRawPassthroughTests` — 5 unit tests (overrides, max_tokens inject-if-absent, verbatim preservation, streaming usage, malformed-body rejection).
- `AnthropicChatModelRawPassthroughIT` — live tests gated on `ANTHROPIC_API_KEY` (token counts, tool calls surfaced without local execution, provider-error propagation).
- Full `spring-ai-anthropic` module suite: 125/125 green; spring-javaformat clean.